### PR TITLE
feat: implement multi-tab call blocking

### DIFF
--- a/components/ui/alert.tsx
+++ b/components/ui/alert.tsx
@@ -11,6 +11,8 @@ const alertVariants = cva(
         default: "bg-background text-foreground",
         destructive:
           "border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive",
+        warning:
+          "border-yellow-500 bg-yellow-50 text-yellow-900 dark:border-yellow-500 [&>svg]:text-yellow-500",
       },
     },
     defaultVariants: {


### PR DESCRIPTION
## Objetivo

Implementar sistema de bloqueio de interface quando há chamadas ativas em outras abas, resolvendo o problema de closure stale no `handleSocketEvent` e melhorando a experiência do usuário em cenários com múltiplas abas.

_Closure Stale: acontece quando uma função "captura" o valor de uma variável no momento em que foi criada, mas essa variável muda depois, e a função continua usando o valor antigo. [(PAUL, Soviv Stale Closures in React)](https://javascript.plainenglish.io/stale-closures-in-react-afb0dda37f0b#:~:text=A%20stale%20closure%20occurs%20when%20an%20inner%20function%20captures%20and%20retains%20an%20outdated%20or%20no%20longer%20valid%20reference%20from%20its%20outer%20function%E2%80%99s%20scope. ))_ 

## Principais Mudanças

### 1. **Correção do Closure Stale**
- Adicionado `phoneNumberRef` para resolver problema de valores desatualizados no `handleSocketEvent`
- Implementados refs adicionais: `isCallQualifiedRef`, `callFinishedRef`, `isCallActiveInAnotherTabRef`
- Sincronização automática entre estados e refs via `useEffect`

### 2. **Sistema de Detecção Multi-Tab**
- No evento "call-was-connected" é validado se o número discado é o mesmo que chegou no socket, isso é feito para detectar a origem da chamada (aba atual vs outras abas)

### 3. **Interface de Bloqueio**
- Novo tipo de alerta `warning` com ícone `TriangleAlert`
- Bloqueio condicional da interface quando `isCallActiveInAnotherTab = true`
- Ocultação da seção de discagem quando há chamada ativa em outra aba

### 4. **Gerenciamento de Estado Aprimorado**
- Reset automático do bloqueio nos eventos `manual-call-was-qualified` e `call-history-was-created`
- Condições inteligentes para evitar atualizações desnecessárias em abas bloqueadas
- Limpeza adequada de estados ao resetar chamadas

### 5. **Melhorias de UX**
- Ícone `PhoneOff` no botão de encerrar chamada
- Botão de desconectar na tela de campanhas
- Correção do campo `sid` na interface `CallData`

## 🧪 Cenários para testar e validar a feature

### Teste Multi-Tab
1. Abrir 2 abas do HubSpot ou localhost com Click-to-Call
2. Conectar e fazer login em ambas
3. Digitar números diferentes em cada aba
4. Iniciar chamada em uma aba
5. **Resultado**: Aba que não iniciou fica bloqueada com aviso

## 🔄 Fluxo de Funcionamento

```mermaid
graph TD
    A[Chamada Iniciada] --> B{Número no phoneNumberRef?}
    B -->|Sim| C[Interface Normal]
    B -->|Não| D[Bloquear Interface]
    D --> E[Mostrar Aviso Warning]
    E --> F[Aguardar Fim da Chamada]
    F --> G[Reset Automático]
    G --> H[Interface Liberada]
```

## 📊 Arquivos Modificados

- `components/click-to-call-system.tsx` - Lógica principal e interface
- `components/ui/alert.tsx` - Novo variant `warning`

## ⚠️ Breaking Changes

Nenhum breaking change. Todas as mudanças são aditivas e mantêm compatibilidade.