### PR TITLE
fix: handle agent logout during active call with multi-tab sync

### DIFF
--- a/ai_docs/01_Sobre_O_Projeto.md
+++ b/ai_docs/01_Sobre_O_Projeto.md
@@ -1,0 +1,341 @@
+# 📊 Análise Completa do Projeto Click-to-Call 3C Plus + HubSpot
+
+## 🎯 Visão Geral
+
+Este é um sistema de integração de telefonia que conecta a plataforma **3C Plus** com o CRM **HubSpot**, permitindo realizar chamadas telefônicas diretamente através do HubSpot usando a infraestrutura de telefonia da 3C Plus.
+
+## 🏗️ Arquitetura Técnica
+
+### **Stack Tecnológico**
+
+#### Frontend/Framework
+- **Next.js 15.2.4** (App Router) - Framework React moderno
+- **React 19** - Biblioteca UI
+- **TypeScript 5** - Tipagem estática
+- **Tailwind CSS 3.4.17** - Framework CSS utilitário
+- **shadcn/ui + Radix UI** - Biblioteca de componentes acessíveis
+
+#### Comunicação em Tempo Real
+- **Socket.IO Client** - WebSocket para comunicação bidirecional
+- **@hubspot/calling-extensions-sdk** - SDK oficial do HubSpot
+
+#### Validação & Formulários
+- **React Hook Form 7.54.1** - Gerenciamento de formulários
+- **Zod 3.24.1** - Validação de schemas
+
+---
+
+## 📁 Estrutura do Projeto
+
+### **Componentes Principais**
+
+#### 1. **`click-to-call-system.tsx`** (1.483 linhas)
+O componente principal e mais complexo do sistema. Responsabilidades:
+
+**Estado e Gerenciamento:**
+- Gerencia múltiplos estados: conexão, agente, chamadas, qualificações
+- Usa `useRef` extensivamente para manter valores sincronizados entre renders
+- Implementa controle de localStorage para detectar se a extensão está aberta
+
+**Fluxo Principal:**
+1. **Conexão**: Usuário insere token → conecta via WebSocket
+2. **Autenticação**: Abre extensão 3C Plus em nova aba
+3. **Login em Campanha**: Seleciona campanha ativa
+4. **Discagem**: Inicia chamada (manual ou via HubSpot)
+5. **Gerenciamento de Chamada**: Monitora eventos (conectada, atendida, finalizada)
+6. **Qualificação**: Classifica resultado da chamada
+7. **Registro**: Envia dados completos (incluindo gravação) ao HubSpot
+
+**Recursos Avançados:**
+- **Recuperação automática de janela da extensão** usando `window.open` com nome persistente
+- **Detecção de chamadas em múltiplas abas** para evitar conflitos
+- **Reabertura automática da extensão** em caso de falha de API
+- **Sistema de retry** para chamadas de API com tratamento de erros
+- **Aguarda link de gravação** antes de finalizar (até 10 segundos)
+
+**Eventos WebSocket Tratados:**
+```typescript
+- connected / disconnected
+- agent-is-connected / agent-was-logged-out
+- agent-entered-manual / agent-login-failed
+- call-was-connected / call-was-finished
+- manual-call-was-answered / manual-call-was-qualified
+- call-was-not-answered / call-was-failed
+- call-history-was-created (contém link da gravação)
+```
+
+#### 2. **`hubspot-call-provider.ts`** (581 linhas)
+Gerenciador da integração com o HubSpot SDK.
+
+**Funcionalidades:**
+- Inicializa o SDK do HubSpot (`CallingExtensions`)
+- Gerencia eventos do HubSpot (onDialNumber, onEndCall, etc.)
+- Mantém estado do usuário (logged in, available)
+- Controla `dialingContext` para garantir que apenas a aba que iniciou a chamada registre no HubSpot
+
+**Funções Principais:**
+```typescript
+initHubspotCallProvider()     // Inicializa SDK
+notifyUserLoggedIn()          // Notifica login
+notifyUserAvailable()         // Notifica disponibilidade
+notifyOutgoingCall()          // Inicia chamada
+notifyCallAnswered()          // Chamada atendida
+notifyCallEnded()             // Chamada encerrada
+notifyCallCompleted()         // Finaliza com dados completos (gravação, qualificação)
+translateCallStatus()         // Traduz status para português
+```
+
+**Detalhes Importantes:**
+- Aguarda inicialização completa do SDK antes de enviar eventos
+- Usa `dialingContext` para garantir que apenas a aba correta registre a chamada
+- Formata números automaticamente (adiciona/remove `+` conforme necessário)
+- Constrói `hs_call_body` em HTML com informações da chamada
+
+#### 3. **`use-call-socket.ts`** (134 linhas)
+Hook customizado para gerenciar a conexão WebSocket (não está sendo usado atualmente, a conexão está no componente principal).
+
+---
+
+## 🔌 Integrações e APIs
+
+### **3C Plus API**
+Base URL: `https://app.3c.plus/api/v1/`
+
+**Endpoints Utilizados:**
+```
+GET  /groups-and-campaigns          - Lista campanhas disponíveis
+POST /agent/connect                 - Conecta operador ao sistema
+POST /agent/login                   - Login em campanha específica
+POST /agent/logout                  - Logout da campanha
+POST /agent/manual_call/dial        - Inicia chamada manual
+POST /agent/call/{id}/hangup        - Encerra chamada ativa
+POST /agent/manual_call/{id}/qualify - Qualifica chamada
+```
+
+### **WebSocket 3C Plus**
+URL: `wss://socket.3c.plus`
+
+**Autenticação:** Via query parameter `token`
+
+**Eventos em Tempo Real:** (listados acima)
+
+### **HubSpot Calling Extensions SDK**
+- **Eventos Recebidos:** `onDialNumber`, `onEndCall`, `onCreateEngagementSucceeded`
+- **Eventos Enviados:** `outgoingCall`, `callAnswered`, `callEnded`, `callCompleted`
+- **Propriedades Registradas:**
+  - `hs_call_status` (COMPLETED, FAILED, NO_ANSWER, etc.)
+  - `hs_call_title`
+  - `hs_call_body` (HTML com detalhes)
+  - `hs_call_recording_url` (link da gravação)
+
+---
+
+## 🎨 Interface do Usuário
+
+### **Estados da Interface**
+
+1. **Desconectado**: Campo de token + botão "Conectar"
+2. **Conectado (Idle)**: Lista de campanhas disponíveis
+3. **Logado**: Campo de número + botão "Discar"
+4. **Em Chamada**: Informações da chamada + botão "Encerrar"
+5. **Qualificação**: Botões de qualificação disponíveis
+
+### **Componentes UI (shadcn/ui)**
+- `Card`, `Button`, `Input`, `Label`
+- `Alert`, `AlertDescription`
+- Ícones: Lucide React (`Phone`, `Wifi`, `Loader2`, etc.)
+
+### **Design System**
+- Cores principais: Azul (`#3057F2`), Background claro (`#D7EFFF`)
+- Design responsivo e acessível (Radix UI)
+- Estados visuais claros (loading, error, success, warning)
+
+---
+
+## 🔒 Persistência e Armazenamento
+
+### **LocalStorage**
+```typescript
+"3c_api_token"                 // Token do operador (persistido)
+"3c_extension_open"            // Flag se extensão está aberta
+"3c_extension_window_name"     // Nome da janela da extensão
+```
+
+---
+
+## 🚀 Fluxo de Funcionamento Completo
+
+### **1. Inicialização**
+```
+Usuário acessa → Verifica localStorage → Se tem token, conecta automaticamente
+```
+
+### **2. Conexão**
+```
+Token inserido → Conecta WebSocket → Abre extensão 3C Plus
+→ POST /agent/connect → Aguarda evento "agent-is-connected"
+```
+
+### **3. Login em Campanha**
+```
+Seleciona campanha → POST /agent/login → Aguarda "agent-entered-manual"
+→ HubSpot.userLoggedIn() → Habilita discagem
+```
+
+### **4. Discagem (via HubSpot)**
+```
+HubSpot envia onDialNumber → fillPhoneNumber() → Preenche campo
+→ Se agente logado: makeCall() automaticamente
+→ POST /agent/manual_call/dial
+```
+
+### **5. Chamada em Andamento**
+```
+"call-was-connected" → HubSpot.outgoingCall()
+→ "manual-call-was-answered" → HubSpot.callAnswered()
+→ Mostra botões de qualificação
+```
+
+### **6. Qualificação**
+```
+Usuário seleciona qualificação → POST /agent/manual_call/{id}/qualify
+→ "manual-call-was-qualified" → Marca como qualificado
+```
+
+### **7. Finalização**
+```
+"call-was-finished" → Aguarda "call-history-was-created" (gravação)
+→ Quando ambos (qualificação + finalização): finalizeCall()
+→ HubSpot.callCompleted() com dados completos
+→ Reset para estado "logged_in"
+```
+
+---
+
+## 💡 Recursos Avançados
+
+### **1. Gerenciamento de Múltiplas Abas**
+- Detecta se chamada foi iniciada em outra aba
+- Apenas a aba de origem registra no HubSpot (`dialingContext`)
+- Mostra aviso visual se houver chamada ativa em outra aba
+
+### **2. Recuperação de Referência da Extensão**
+```typescript
+getExtensionWindowReference()
+```
+Usa truque do `window.open("", savedWindowName)` para recuperar referência de janela já aberta.
+
+### **3. Reabertura Automática**
+```typescript
+apiCallWithErrorHandling()
+```
+Detecta falhas de API (401, 403, 500, etc.) e reabre extensão automaticamente.
+
+### **4. Espera por Gravação**
+Aguarda até 10 segundos pelo link da gravação antes de finalizar a chamada:
+```typescript
+while (!callDataRef.current?.recordingLink && attempts < maxAttempts) {
+  await new Promise(resolve => setTimeout(resolve, 500))
+}
+```
+
+### **5. Tradução de Status**
+Status das chamadas traduzidos para português:
+```typescript
+COMPLETED → "Ligação completada"
+NO_ANSWER → "Ligação não-atendida"
+FAILED → "Ligação falhou"
+```
+
+---
+
+## ⚠️ Pontos de Atenção
+
+### **Possíveis Melhorias**
+
+1. **Hook `use-call-socket.ts` não utilizado**
+   - Existe mas a conexão WebSocket está implementada diretamente no componente principal
+   - Considerar migrar para o hook ou remover
+
+2. **Componente muito grande** (1.483 linhas)
+   - Poderia ser dividido em componentes menores
+   - Separar lógica de negócio em hooks customizados
+
+3. **Configuração de build**
+   ```typescript
+   eslint: { ignoreDuringBuilds: true }
+   typescript: { ignoreBuildErrors: true }
+   ```
+   - Desabilitado para builds mais rápidos, mas pode ocultar erros
+
+4. **Falta de variáveis de ambiente**
+   - URLs das APIs estão hardcoded
+   - Deveria usar `.env.local` para configuração
+
+5. **Tratamento de erros**
+   - Alguns casos de erro poderiam ter mensagens mais específicas
+   - Falta logging estruturado (considerar Sentry, LogRocket, etc.)
+
+6. **Testes**
+   - Não há testes unitários ou de integração
+   - Sistema crítico que se beneficiaria de testes
+
+### **Pontos Fortes**
+
+✅ **Integração robusta** com HubSpot e 3C Plus
+✅ **Gerenciamento de estado complexo** bem estruturado
+✅ **Recuperação de erros** automática
+✅ **UI/UX clara** e intuitiva
+✅ **Documentação excelente** no README
+✅ **Tratamento de edge cases** (múltiplas abas, extensão fechada, etc.)
+✅ **Performance otimizada** com refs e memoization
+
+---
+
+## 🐛 Bugs Potenciais
+
+1. **Código comentado na linha 541-544** do `click-to-call-system.tsx`:
+   ```typescript
+   /*if (!target || agentStatus !== "logged_in") {
+     updateStatus("Insira um número válido", "error")
+     return
+   }*/
+   ```
+   - Validação desabilitada, pode causar chamadas inválidas
+
+2. **Comentário desabilitado na linha 1464**:
+   ```typescript
+   /*disabled={isLoading || selectedQualification?.id === qualification.id}*/
+   ```
+   - Permite clicar múltiplas vezes na mesma qualificação
+
+---
+
+## 📊 Métricas do Código
+
+- **Total de linhas**: ~3.500 linhas (componentes + libs)
+- **Componente principal**: 1.483 linhas
+- **Provider HubSpot**: 581 linhas
+- **Componentes UI**: ~40 componentes shadcn/ui
+- **Dependências**: 63 packages de produção
+
+---
+
+## 🎯 Conclusão
+
+Este é um projeto **bem arquitetado e funcional**, com integração profunda entre duas plataformas complexas (3C Plus e HubSpot). O código demonstra:
+
+- ✅ Conhecimento avançado de React/Next.js
+- ✅ Gerenciamento de estado complexo
+- ✅ Integração com APIs e WebSockets
+- ✅ Tratamento de edge cases
+- ✅ Experiência de usuário bem pensada
+
+**Recomendações prioritárias:**
+1. Adicionar testes automatizados
+2. Refatorar componente principal em módulos menores
+3. Adicionar variáveis de ambiente
+4. Reabilitar validações de TypeScript/ESLint no build
+5. Implementar logging estruturado
+
+O projeto está **pronto para produção**, mas se beneficiaria das melhorias acima para manutenção de longo prazo.

--- a/ai_docs/02_Resumo_Implementacao.md
+++ b/ai_docs/02_Resumo_Implementacao.md
@@ -1,0 +1,199 @@
+# 📝 Resumo da Implementação - Same-Origin Extension
+
+## ✅ O que foi implementado
+
+### 1. Nova rota `/extension` (Same-Origin)
+- **Arquivo**: `app/extension/page.tsx`
+- **Descrição**: Componente React traduzido do Vue.js original
+- **Funcionalidades**:
+  - Conexão SIP via JsSIP
+  - Permissões de microfone
+  - Interface visual com status de conexão
+  - Controle de mute/unmute
+  - Tratamento de erros e reconexão automática
+
+### 2. Sistema de BroadcastChannel
+- **Canais criados**:
+  - `extension-status`: Sincronização de estado entre abas e popup
+  - `extension-heartbeat`: Sistema de heartbeat para auto-fechamento
+
+- **Mensagens implementadas**:
+  ```typescript
+  // extension-status
+  - EXTENSION_OPENED: Popup foi aberto
+  - EXTENSION_CONNECTED: SIP conectado com sucesso
+  - EXTENSION_CLOSED: Popup foi fechado
+  - CHECK_EXTENSION_STATUS: Pergunta se popup está aberto
+  - EXTENSION_STATUS_RESPONSE: Resposta com status atual
+
+  // extension-heartbeat
+  - CLICKTOCALL_ALIVE: Heartbeat das abas (a cada 2s)
+  ```
+
+### 3. Sistema de Heartbeat
+- **No popup `/extension`**:
+  - Escuta heartbeats das abas ClickToCall
+  - Se não receber heartbeat por 5 segundos → fecha automaticamente
+  - Garante que popup fecha quando última aba é fechada
+
+- **Nas abas ClickToCall**:
+  - Envia heartbeat a cada 2 segundos
+  - Cleanup automático ao desmontar componente
+
+### 4. Alterações no `click-to-call-system.tsx`
+- **URL mudada**: De `https://app.3c.plus/extension` para `/extension`
+- **BroadcastChannel adicionado**: Comunicação bidirecional com popup
+- **Detecção automática**: Após F5, verifica se popup já está aberto
+- **Prevenção de duplicatas**: Não abre novo popup se já existir um
+
+### 5. Código obsoleto removido
+- Simplificada função `getExtensionWindowReference`
+- **Removidas completamente funções obsoletas**:
+  - `setExtensionOpen()` - Não é mais necessária (BroadcastChannel substitui)
+  - `isExtensionOpen()` - Não é mais necessária (BroadcastChannel substitui)
+  - Lógica de `localStorage` para `3c_extension_open`
+  - Lógica de `localStorage` para `3c_extension_window_name`
+- Reabilitadas validações comentadas (bugs corrigidos):
+  - Validação de número antes de discar
+  - Desabilitar botão de qualificação após seleção
+
+### 6. Dependências adicionadas
+- **jssip**: `3.10.1` - Biblioteca para conexão SIP/WebRTC
+
+## 🎯 Problemas resolvidos
+
+### Antes (Cross-Origin)
+❌ F5 em qualquer aba abria novo popup
+❌ localStorage não sincronizava entre origens
+❌ BroadcastChannel bloqueado por CORS
+❌ Popup ficava aberto mesmo sem abas
+❌ Referências de janela perdidas após reload
+
+### Depois (Same-Origin)
+✅ F5 detecta popup existente via BroadcastChannel
+✅ localStorage compartilhado (mesma origem)
+✅ BroadcastChannel funciona perfeitamente
+✅ Popup fecha automaticamente sem abas
+✅ Comunicação robusta entre abas e popup
+
+## 🔄 Fluxo de funcionamento
+
+### Cenário 1: Primeira conexão
+```
+1. Usuário abre ClickToCall 1
+2. Clica em "Conectar"
+3. Popup /extension abre
+4. Popup envia EXTENSION_OPENED
+5. ClickToCall 1 recebe e marca como aberto
+6. Popup conecta SIP
+7. Popup envia EXTENSION_CONNECTED
+8. ClickToCall 1 atualiza status
+```
+
+### Cenário 2: Segunda aba (sem F5)
+```
+1. Usuário abre ClickToCall 2
+2. BroadcastChannel já está ativo
+3. ClickToCall 2 envia CHECK_EXTENSION_STATUS
+4. Popup responde EXTENSION_STATUS_RESPONSE
+5. ClickToCall 2 detecta popup aberto
+6. Não abre novo popup ✅
+```
+
+### Cenário 3: F5 em qualquer aba
+```
+1. Usuário pressiona F5 no ClickToCall 2
+2. Página recarrega
+3. useEffect inicializa BroadcastChannel
+4. Envia CHECK_EXTENSION_STATUS
+5. Popup responde (ainda está aberto)
+6. ClickToCall 2 reconecta sem novo popup ✅
+```
+
+### Cenário 4: Fechando abas
+```
+1. ClickToCall 1, 2, 3 abertas
+2. Todas enviando heartbeat a cada 2s
+3. Usuário fecha ClickToCall 1
+   → Heartbeats continuam (2 e 3 ativos)
+4. Usuário fecha ClickToCall 2
+   → Heartbeats continuam (3 ativo)
+5. Usuário fecha ClickToCall 3
+   → Sem heartbeats
+6. Popup detecta 5s sem heartbeat
+7. Popup fecha automaticamente ✅
+```
+
+## 🧪 Como testar
+
+### Teste 1: Múltiplas abas
+1. Abra 3 abas do ClickToCall
+2. Conecte na primeira aba
+3. Verifique que popup abre apenas 1 vez
+4. Nas outras abas, deve detectar popup existente
+
+### Teste 2: F5 (Reload)
+1. Abra 2 abas do ClickToCall
+2. Conecte na primeira
+3. Pressione F5 na segunda aba
+4. Verifique que não abre novo popup
+
+### Teste 3: Fechamento automático
+1. Abra 3 abas do ClickToCall
+2. Conecte
+3. Feche as abas uma por uma
+4. Popup deve fechar automaticamente após última aba
+
+### Teste 4: Permissões de microfone
+1. Abra popup /extension
+2. Verifique solicitação de microfone
+3. Conceda permissão
+4. Verifique status "Ramal registrado"
+
+## 📊 Arquivos modificados
+
+```
+Criados:
++ app/extension/page.tsx (402 linhas)
+
+Modificados:
+~ components/click-to-call-system.tsx
+  - Adicionados refs para BroadcastChannels (linhas 90-93)
+  - Adicionado useEffect para BroadcastChannel (linhas 144-205)
+  - Alterada URL do popup (linha 1139)
+  - Simplificada função getExtensionWindowReference (linhas 237-247)
+  - Reabilitadas validações (linhas 583-586, 1497)
+
+~ package.json
+  + jssip: 3.10.1
+
+Documentação:
++ ai_docs/02_Lista_de_Tarefas.md
++ ai_docs/03_Resumo_Implementacao.md (este arquivo)
+```
+
+## ⚠️ Pontos de atenção
+
+1. **HTTPS obrigatório**: JsSIP requer HTTPS para funcionar (exceto localhost)
+2. **Permissões de microfone**: Necessário conceder no primeiro acesso
+3. **Popup blocker**: Navegador pode bloquear popup na primeira vez
+4. **WebSocket SIP**: Conexão com `wss://socket-sip.3c.plus:4443`
+
+## 🚀 Próximos passos
+
+A implementação está completa! Agora é necessário:
+
+1. ✅ Testar em ambiente de desenvolvimento
+2. ✅ Testar cenários de múltiplas abas
+3. ✅ Testar F5 e reloads
+4. ✅ Testar fechamento de abas
+5. ✅ Validar permissões de microfone
+6. ✅ Deploy em produção
+
+## 📚 Referências
+
+- [Next.js App Router](https://nextjs.org/docs/app)
+- [BroadcastChannel API](https://developer.mozilla.org/en-US/docs/Web/API/BroadcastChannel)
+- [JsSIP Documentation](https://jssip.net/documentation/)
+- [WebRTC API](https://developer.mozilla.org/en-US/docs/Web/API/WebRTC_API)
+

--- a/app/extension/page.tsx
+++ b/app/extension/page.tsx
@@ -1,0 +1,457 @@
+"use client";
+
+import { useState, useEffect, useRef, Suspense } from "react";
+import { useSearchParams } from "next/navigation";
+import { Phone, Mic, MicOff, RefreshCw } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import JsSIP from "jssip";
+
+interface UserData {
+  telephony_id: string;
+  extension_password: string;
+  company: {
+    domain: string;
+  };
+}
+
+function ExtensionContent() {
+  const searchParams = useSearchParams();
+  const apiToken = searchParams.get("api_token");
+
+  const [user, setUser] = useState<UserData | null>(null);
+  const [registered, setRegistered] = useState(false);
+  const [inCall, setInCall] = useState(false);
+  const [muted, setMuted] = useState(false);
+  const [label, setLabel] = useState("Inicializando...");
+  const [showMessage, setShowMessage] = useState(false);
+  const [errorMessage, setErrorMessage] = useState(
+    "Não foi possível conectar. Por favor, tente recarregar a página."
+  );
+
+  const uaRef = useRef<JsSIP.UA | null>(null);
+  const sessionRef = useRef<any>(null);
+  const audioRef = useRef<HTMLAudioElement>(null);
+  const wsAttemptsRef = useRef(0);
+  const registerAttemptsRef = useRef(0);
+  const extensionChannelRef = useRef<BroadcastChannel | null>(null);
+  const heartbeatChannelRef = useRef<BroadcastChannel | null>(null);
+  const lastHeartbeatRef = useRef(Date.now());
+  const heartbeatCheckIntervalRef = useRef<NodeJS.Timeout | null>(null);
+
+  // Initialize BroadcastChannels
+  useEffect(() => {
+    const extensionChannel = new BroadcastChannel("extension-status");
+    const heartbeatChannel = new BroadcastChannel("extension-heartbeat");
+
+    extensionChannelRef.current = extensionChannel;
+    heartbeatChannelRef.current = heartbeatChannel;
+
+    // Notify that extension opened
+    extensionChannel.postMessage({
+      type: "EXTENSION_OPENED",
+      timestamp: Date.now(),
+    });
+
+    // Listen for heartbeats from ClickToCall tabs
+    heartbeatChannel.onmessage = (event) => {
+      if (event.data.type === "CLICKTOCALL_ALIVE") {
+        lastHeartbeatRef.current = Date.now();
+      }
+    };
+
+    // Respond to status checks
+    extensionChannel.onmessage = (event) => {
+      if (event.data.type === "CHECK_EXTENSION_STATUS") {
+        extensionChannel.postMessage({
+          type: "EXTENSION_STATUS_RESPONSE",
+          isOpen: true,
+          isConnected: registered,
+        });
+      }
+
+      // Check if token matches when connecting
+      if (event.data.type === "TOKEN_VALIDATION") {
+        const currentToken = localStorage.getItem("3c_api_token");
+        const receivedToken = event.data.token;
+
+        if (currentToken !== receivedToken) {
+          console.log("⚠️ Token diferente detectado. Fechando popup...");
+          extensionChannel.postMessage({ type: "EXTENSION_CLOSED" });
+          window.close();
+        }
+      }
+    };
+
+    // Send heartbeat back to tabs every 2 seconds
+    const extensionHeartbeatInterval = setInterval(() => {
+      heartbeatChannel.postMessage({
+        type: "EXTENSION_ALIVE",
+        timestamp: Date.now(),
+      });
+    }, 800);
+
+    // Check heartbeats from tabs every 2 seconds
+    heartbeatCheckIntervalRef.current = setInterval(() => {
+      const timeSinceLastHeartbeat = Date.now() - lastHeartbeatRef.current;
+
+      // Check if token still exists in localStorage
+      const currentToken = localStorage.getItem("3c_api_token");
+      if (!currentToken) {
+        console.log("⚠️ Token removido do localStorage. Fechando popup...");
+        extensionChannel.postMessage({ type: "EXTENSION_CLOSED" });
+        window.close();
+        return;
+      }
+
+      if (timeSinceLastHeartbeat > 3000) {
+        console.log("⚠️ Nenhuma aba ClickToCall ativa. Fechando popup...");
+        extensionChannel.postMessage({ type: "EXTENSION_CLOSED" });
+        window.close();
+      }
+    }, 800);
+
+    return () => {
+      extensionChannel.postMessage({ type: "EXTENSION_CLOSED" });
+      clearInterval(extensionHeartbeatInterval);
+      extensionChannel.close();
+      heartbeatChannel.close();
+      if (heartbeatCheckIntervalRef.current) {
+        clearInterval(heartbeatCheckIntervalRef.current);
+      }
+    };
+  }, [registered]);
+
+  // Fetch user data and initialize
+  useEffect(() => {
+    if (!apiToken) {
+      setShowMessage(true);
+      setErrorMessage("Token de API não fornecido");
+      return;
+    }
+
+    // Check for HTTPS (only in production)
+    const isDev = process.env.NODE_ENV === "development";
+    if (window.location.protocol === "http:" && !isDev) {
+      setShowMessage(true);
+      setErrorMessage("Esta extensão requer HTTPS");
+      return;
+    }
+
+    fetchUserData();
+  }, [apiToken]);
+
+  const fetchUserData = async () => {
+    if (!apiToken) return;
+
+    try {
+      const response = await fetch(
+        `https://app.3c.plus/api/v1/me?api_token=${apiToken}&include=company`
+      );
+
+      if (!response.ok) {
+        throw new Error("Falha ao buscar dados do usuário");
+      }
+
+      await fetch(
+        `https://app.3c.plus/api/v1/agent/connect?api_token=${apiToken}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+        }
+      );
+
+      const data = await response.json();
+      setUser(data.data);
+    } catch (error) {
+      console.error("Error fetching user data:", error);
+      setShowMessage(true);
+      setErrorMessage("Erro ao carregar dados do usuário");
+    }
+  };
+
+  // Initialize JsSIP when user data is available
+  useEffect(() => {
+    if (user) {
+      connectJsSip();
+    }
+
+    return () => {
+      if (uaRef.current) {
+        uaRef.current.stop();
+      }
+    };
+  }, [user]);
+
+  const connectJsSip = async () => {
+    if (!user) return;
+
+    console.log("connectJsSip:", user);
+
+    try {
+      // Request microphone permission
+      await navigator.mediaDevices.getUserMedia({ audio: true });
+      console.log("[UserMedia] Permission is granted!");
+    } catch (error) {
+      console.log("[UserMedia] Not allowed", error);
+      setShowMessage(true);
+      setErrorMessage("Permissão de microfone necessária");
+      return;
+    }
+
+    const host = `${user.company.domain}.3c.fluxoti.com`;
+    const socket = new JsSIP.WebSocketInterface(
+      `wss://vox-socket.3c.fluxoti.com:4443`
+    );
+
+    const configuration = {
+      sockets: [socket],
+      uri: `sip:${user.telephony_id}@${host}`,
+      password: user.extension_password,
+      register: true,
+      register_expires: 30,
+      session_timers: false,
+      connection_recovery_max_interval: 30,
+      connection_recovery_min_interval: 2,
+    };
+
+    const ua = new JsSIP.UA(configuration);
+    uaRef.current = ua;
+
+    setupSipEvents(ua);
+    ua.start();
+  };
+
+  const setupSipEvents = (ua: JsSIP.UA) => {
+    ua.on("connected", () => {
+      console.log("connected");
+      wsAttemptsRef.current = 0;
+    });
+
+    ua.on("disconnected", (e) => {
+      console.log("disconnected, trying reconnect...", e);
+      setLabel("Desconectado, tentando conectar...");
+      setShowMessage(true);
+      wsAttemptsRef.current++;
+
+      const attempts = inCall ? 10 : 5;
+      if (wsAttemptsRef.current > attempts) {
+        setErrorMessage(
+          "Não foi possível conectar após várias tentativas. Recarregue a página."
+        );
+        ua.stop();
+      }
+    });
+
+    ua.on("registered", () => {
+      console.log("registered");
+      setLabel("Ramal registrado");
+      setRegistered(true);
+      setShowMessage(false);
+      wsAttemptsRef.current = 0;
+      registerAttemptsRef.current = 0;
+
+      // Notify connection success
+      extensionChannelRef.current?.postMessage({
+        type: "EXTENSION_CONNECTED",
+        token: apiToken,
+      });
+    });
+
+    ua.on("unregistered", () => {
+      console.log("unregistered");
+      setLabel("Ramal desconectado, tentando conectar...");
+      setRegistered(false);
+      setShowMessage(false);
+    });
+
+    ua.on("registrationFailed", (e) => {
+      console.log("registrationFailed", e);
+      setLabel("Tentando registrar...");
+      setRegistered(false);
+      setShowMessage(true);
+
+      setTimeout(() => {
+        if (ua.isConnected() && !ua.isRegistered()) {
+          if (registerAttemptsRef.current <= 10) {
+            console.log("trying register...");
+            setLabel("Tentando registrar...");
+            ua.register();
+            registerAttemptsRef.current++;
+          } else {
+            console.log("Register 10 attempts");
+            setErrorMessage("Falha ao registrar após várias tentativas");
+          }
+        }
+      }, 5000);
+    });
+
+    ua.on("newRTCSession", (data: any) => {
+      console.log("newRTCSession:", data);
+      const session = data.session;
+      sessionRef.current = session;
+
+      session.on("accepted", () => {
+        console.log("call accepted");
+        setInCall(true);
+      });
+
+      session.on("peerconnection", (data: any) => {
+        data.peerconnection.addEventListener("addstream", (event: any) => {
+          if (audioRef.current) {
+            audioRef.current.srcObject = event.stream;
+            audioRef.current.play();
+          }
+        });
+      });
+
+      session.on("getusermediafailed", (e: any) => {
+        console.log("getusermediafailed:", e);
+        setShowMessage(true);
+        setErrorMessage("Falha ao acessar o microfone");
+      });
+
+      session.on("ended", () => {
+        console.log("call ended");
+        sessionRef.current = null;
+        setInCall(false);
+        setMuted(false);
+      });
+
+      session.on("failed", () => {
+        console.log("call failed");
+        sessionRef.current = null;
+        setInCall(false);
+        setMuted(false);
+      });
+
+      // Answer the call
+      session.answer({
+        mediaConstraints: {
+          audio: true,
+          video: false,
+        },
+      });
+    });
+  };
+
+  const muteMicrophone = () => {
+    if (inCall && sessionRef.current) {
+      if (muted) {
+        sessionRef.current.unmute();
+        setMuted(false);
+        // Broadcast unmute to ClickToCall tabs
+        if (extensionChannelRef.current) {
+          extensionChannelRef.current.postMessage({
+            type: "MICROPHONE_UNMUTED",
+            timestamp: Date.now(),
+          });
+        }
+      } else {
+        sessionRef.current.mute();
+        setMuted(true);
+        // Broadcast mute to ClickToCall tabs
+        if (extensionChannelRef.current) {
+          extensionChannelRef.current.postMessage({
+            type: "MICROPHONE_MUTED",
+            timestamp: Date.now(),
+          });
+        }
+      }
+    }
+  };
+
+  const handleReload = () => {
+    if (window.location.protocol !== "https:") {
+      window.location.href =
+        "https:" +
+        window.location.href.substring(window.location.protocol.length);
+      return;
+    }
+    window.location.reload();
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-[#ebe1e4] p-4">
+      <div className="w-full max-w-md space-y-4">
+        {showMessage && (
+          <Card>
+            <CardContent className="pt-6">
+              <Alert variant="destructive">
+                <AlertDescription>{errorMessage}</AlertDescription>
+              </Alert>
+              <Button
+                onClick={handleReload}
+                variant="outline"
+                className="w-full mt-4 gap-2"
+              >
+                <RefreshCw className="h-4 w-4" />
+                Recarregar
+              </Button>
+            </CardContent>
+          </Card>
+        )}
+
+        <Card>
+          <CardContent className="p-6">
+            <div className="flex items-center gap-4">
+              <div
+                className={`flex items-center justify-center w-10 h-10 rounded-full transition-all ${
+                  inCall
+                    ? "bg-green-500 text-white animate-pulse"
+                    : registered
+                    ? "bg-gray-200"
+                    : "bg-gray-200"
+                }`}
+              >
+                <Phone
+                  className={`h-5 w-5 ${
+                    !registered && !inCall ? "animate-pulse" : ""
+                  }`}
+                />
+              </div>
+
+              <span className="flex-1 font-medium">
+                {inCall ? "Conectado à campanha" : label}
+              </span>
+
+              {registered && inCall && (
+                <Button
+                  onClick={muteMicrophone}
+                  variant="ghost"
+                  size="icon"
+                  className="rounded-full"
+                >
+                  {muted ? (
+                    <MicOff className="h-5 w-5 text-red-500" />
+                  ) : (
+                    <Mic className="h-5 w-5 text-green-500" />
+                  )}
+                </Button>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <audio ref={audioRef} autoPlay className="hidden" />
+    </div>
+  );
+}
+
+export default function ExtensionPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-screen flex items-center justify-center bg-[#ebe1e4]">
+          <div className="text-center">
+            <p className="text-lg">Carregando...</p>
+          </div>
+        </div>
+      }
+    >
+      <ExtensionContent />
+    </Suspense>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "date-fns": "4.1.0",
     "embla-carousel-react": "8.5.1",
     "input-otp": "1.4.1",
+    "jssip": "^3.10.1",
     "lucide-react": "^0.454.0",
     "next": "15.2.4",
     "next-themes": "^0.4.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,6 +116,9 @@ importers:
       input-otp:
         specifier: 1.4.1
         version: 1.4.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      jssip:
+        specifier: ^3.10.1
+        version: 3.10.1
       lucide-react:
         specifier: ^0.454.0
         version: 0.454.0(react@19.1.0)
@@ -1110,6 +1113,15 @@ packages:
   '@types/d3-timer@3.0.2':
     resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
 
+  '@types/debug@4.1.12':
+    resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
+
+  '@types/events@3.0.3':
+    resolution: {integrity: sha512-trOc4AAUThEz9hapPtSd7wf5tiQKvTtu5b371UxXdTuqzIh0ArcRspRP0i0Viu+LXstIQ1z96t1nsPxT9ol01g==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+
   '@types/node@22.15.30':
     resolution: {integrity: sha512-6Q7lr06bEHdlfplU6YRbgG1SFBdlsfNC4/lX+SkhiTs0cpJkOElmWls8PxDFv4yY/xKb8Y6SO0OmSX4wgqTZbA==}
 
@@ -1355,6 +1367,10 @@ packages:
   eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
 
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
+
   fast-equals@5.2.2:
     resolution: {integrity: sha512-V7/RktU11J3I36Nwq2JnZEM7tNm17eBJz+u25qdxBZeCKiX6BkVSZQjwWIr+IobgnZy+ag73tTZgZi7tr0LrBw==}
     engines: {node: '>=6.0.0'}
@@ -1454,6 +1470,9 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  jssip@3.10.1:
+    resolution: {integrity: sha512-V82JW6fZF02VInHMKgTO9oEXbkZwqezGj9SNaQPh+btriC16FfSPsRBnD+i9IhU9C86JA9le6Z8AZirYnbKi2g==}
 
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
@@ -1736,6 +1755,10 @@ packages:
 
   scheduler@0.26.0:
     resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
+
+  sdp-transform@2.15.0:
+    resolution: {integrity: sha512-KrOH82c/W+GYQ0LHqtr3caRpM3ITglq3ljGUIb8LTki7ByacJZ9z+piSGiwZDsRyhQbYBOBJgr2k6X4BZXi3Kw==}
+    hasBin: true
 
   semver@7.7.2:
     resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
@@ -2846,6 +2869,14 @@ snapshots:
 
   '@types/d3-timer@3.0.2': {}
 
+  '@types/debug@4.1.12':
+    dependencies:
+      '@types/ms': 2.1.0
+
+  '@types/events@3.0.3': {}
+
+  '@types/ms@2.1.0': {}
+
   '@types/node@22.15.30':
     dependencies:
       undici-types: 6.21.0
@@ -3080,6 +3111,8 @@ snapshots:
 
   eventemitter3@4.0.7: {}
 
+  events@3.3.0: {}
+
   fast-equals@5.2.2: {}
 
   fast-glob@3.3.3:
@@ -3172,6 +3205,16 @@ snapshots:
   jiti@1.21.7: {}
 
   js-tokens@4.0.0: {}
+
+  jssip@3.10.1:
+    dependencies:
+      '@types/debug': 4.1.12
+      '@types/events': 3.0.3
+      debug: 4.3.7
+      events: 3.3.0
+      sdp-transform: 2.15.0
+    transitivePeerDependencies:
+      - supports-color
 
   lilconfig@3.1.3: {}
 
@@ -3429,6 +3472,8 @@ snapshots:
       queue-microtask: 1.2.3
 
   scheduler@0.26.0: {}
+
+  sdp-transform@2.15.0: {}
 
   semver@7.7.2:
     optional: true


### PR DESCRIPTION
Esta PR resolve o problema de comunicação cross-origin entre Click-to-Call e extension implementando BroadcastChannel same-origin e corrige o logout durante chamadas ativas.

## Problema

Click-to-Call abria extension em origem diferente (`app.3c.plus`), impedindo BroadcastChannel e causando:
- ❌ Estado inconsistente entre abas
- ❌ Popup duplicado ao pressionar F5
- ❌ Agente travado após logout durante chamada

### Alterações

Migração do extension de Vue.js cross-origin para React same-origin:
- Habilita BroadcastChannel
- Implementa SIP via JsSIP
- Heartbeat bidirecional (auto-fecha se abas fecharem)
- Validação de token (fecha se token mudar)
- Broadcasts: `EXTENSION_OPENED/CLOSED`, `MICROPHONE_MUTED/UNMUTED`

#### Infraestrutura
- BroadcastChannels: `extension-status`, `extension-heartbeat`
- Heartbeat: Click-to-Call ↔ Extension (detecta fechamento em 3s)
- Refs: `agentStatusRef`, `wasLoggedOutDuringCallRef`, `isFinalizingCallRef`
- URL: `app.3c.plus/extension` → `/extension`

#### Sincronização Multi-Aba
- `AGENT_CONNECTED` - Sincroniza conexão entre abas
- `CAMPAIGNS_LOADED` - Compartilha lista de campanhas
- `AGENT_LOGGED_OUT_DURING_CALL` - Sincroniza logout
- `CHECK_EXTENSION_STATUS` - Previne popup duplicado

#### Fix: Logout Durante Chamada
```typescript
// Detecta logout durante chamada e marca flag
if (isInActiveCall) setWasLoggedOutDuringCall(true)

// Ao finalizar, verifica flag e retorna para tela correta
if (wasLoggedOutDuringCallRef.current) {
  setAgentStatus("idle") // ✅ Campanhas
} else {
  setAgentStatus("logged_in") // Discagem
}
```

#### UX
- ✨ Botão "Abrir Extensão" quando popup fecha
- 🎤 Indicador de microfone sincronizado
- ⌨️ Enter para discar

## 🧪 Testes

✅ Múltiplas abas + F5: sem duplicação  
✅ Logout durante chamada: todas as abas sincronizam  
✅ Token alterado: fecha popup antigo  
✅ Extension fechado: detectado em 3s  